### PR TITLE
feat: made vector graphics much more straightforward by relying on co…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# arjun_plot: customized plotting routines in matplotlib 
+# arjun_plot: customized plotting routines in matplotlib
 
 ## Rationale
 
-Over the course of doing research, I've had to generate **many** plots. Typically these have been using custom `matplotlib` routines. The package here has specific classes and modules which help with some common routines in plotting of genetic data.  
+Over the course of doing research, I've had to generate **many** plots. Typically these have been using custom `matplotlib` routines. The package here has specific classes and modules which help with some common routines in plotting of genetic data.
 
 ## Modules
 

--- a/arjun_plot/__init__.py
+++ b/arjun_plot/__init__.py
@@ -4,4 +4,4 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-__version__ = "0.0.1a"
+__version__ = "0.0.1b"

--- a/arjun_plot/statgen.py
+++ b/arjun_plot/statgen.py
@@ -1,6 +1,9 @@
 """Common plotting utilities used in statgen applications."""
 
 import numpy as np
+from scipy.spatial import ConvexHull
+from matplotlib.patches import Polygon
+
 
 HUMAN_CHROMS = [f"chr{i}" for i in range(1, 23)] + ["chrX"]
 
@@ -21,9 +24,51 @@ def qqplot_pval(ax, pvals, **kwargs):
     exp_q = -np.log10(exp_q)
     true_q = -np.log10(true_q)
     # generate the plot as a scatter plot
-    # TODO: should we have some option to thin p-values that are in the upper-levels?
     ax.scatter(exp_q, true_q, **kwargs)
     return ax
+
+
+def plot_null_snps(ax, pos, pvals, q=0.80, threshold=5e6, **kwargs):
+    """Make null-variants a convex hull polygon to save dots in vector graphics.
+
+    :param matplotlib.pyplot.axis ax: Input axis.
+    :param np.array pos:
+    :param np.array pvals: negative log10 transformed p-values
+    :param float q: quantile threshold for grouping effects
+    :param float threshold: threshold for discontinuities in variant positioning
+    """
+    assert pos.size == pvals.size
+    assert threshold > 1e6
+    assert (q > 0) and (q < 1.0)
+    # First determine if there is a discontinuity in SNPs due to the centromere ...
+    discontinuities_idx = np.where(abs(np.diff(pos)) > threshold)[0] + 1
+    if discontinuities_idx.size > 0:
+        discontinuities_idx = np.insert(discontinuities_idx, 0, 0)
+        discontinuities_idx = np.append(discontinuities_idx, pos.size - 1)
+        for j, k in zip(discontinuities_idx[:-1], discontinuities_idx[1:]):
+            cur_pos = pos[(pos >= pos[j]) & (pos < pos[k])]
+            cur_pvals = pvals[(pos >= pos[j]) & (pos < pos[k])]
+
+            null_pvals = cur_pvals[cur_pvals <= np.nanquantile(pvals, q)]
+            null_pos = cur_pos[cur_pvals <= np.nanquantile(pvals, q)]
+            assert null_pvals.size == null_pos.size
+            hull_pts = np.vstack([null_pos, null_pvals]).T
+            hull = ConvexHull(hull_pts)
+            vertex_pts = np.vstack(
+                [hull_pts[hull.vertices, 0], hull_pts[hull.vertices, 1]]
+            ).T
+            ax.add_patch(Polygon(np.array(vertex_pts), **kwargs))
+    else:
+        null_pvals = pvals[pvals < np.nanquantile(pvals, q)]
+        null_pos = pos[pvals < np.nanquantile(pvals, q)]
+        assert null_pvals.size == null_pos.size
+        hull_pts = np.vstack([null_pos, null_pvals]).T
+        hull = ConvexHull(hull_pts)
+        vertex_pts = np.vstack(
+            [hull_pts[hull.vertices, 0], hull_pts[hull.vertices, 1]]
+        ).T
+        ax.add_patch(Polygon(np.array(vertex_pts), **kwargs))
+    return ax, np.nanquantile(pvals, q)
 
 
 def manhattan_plot(
@@ -34,6 +79,9 @@ def manhattan_plot(
     chrom_def=HUMAN_CHROMS,
     thin=1,
     colors=["blue", "orange"],
+    q=0.80,
+    threshold=10e6,
+    padding=20e6,
     **kwargs,
 ):
     """Generate a Manhattan plot using some custom arguments.
@@ -44,9 +92,11 @@ def manhattan_plot(
         pos (np.array):  numpy array of positions (in basepairs).
         pvals (np.array): numpy array of p-values.
         chrom_def (list): list of all possible chromosomes.
-        thin (int): argument to thin every i^th p-value. Set higher for faster plotting.
+        thin (int): thin every i^th p-value. Set higher for faster plotting.
         colors (list): list of two colors to alternate between for chromosomes.
-
+        q (float): quantile below which to aggregate most p-values for plotting
+        threshold (float): threshold for discontinuities
+        padding (float): padding for between-chromosome distances
     Returns:
         ax (matplotlib.axis): axis containing the Manhattan plot.
 
@@ -55,6 +105,7 @@ def manhattan_plot(
     assert pvals.size == pos.size
     assert len(colors) == 2
     assert thin >= 1
+    assert padding > 0
 
     if np.all((pvals >= 0) & (pvals <= 1.0)):
         # Transform to the -log10 scale if necessary
@@ -66,13 +117,28 @@ def manhattan_plot(
         idx = np.where(chroms == x)[0]
         if idx.size > 0:
             cur_pos = pos[idx] - np.min(pos[idx])
-            cur_pvals = pvals[idx]
-            ax.scatter(
-                max_pos + cur_pos[::thin], cur_pvals[::thin], color=colors[i], **kwargs
+            cur_pos = cur_pos[::thin]
+            cur_pvals = pvals[idx][::thin]
+            plot_null_snps(
+                ax,
+                max_pos + cur_pos,
+                cur_pvals,
+                q=q,
+                threshold=threshold,
+                color=colors[i],
             )
-            xpos.append(max_pos + np.mean(cur_pos))
-            max_pos += np.max(cur_pos)
+
+            ax.scatter(
+                max_pos + cur_pos[cur_pvals > np.nanquantile(cur_pvals, q)],
+                cur_pvals[cur_pvals > np.nanquantile(cur_pvals, q)],
+                color=colors[i],
+                **kwargs,
+            )
+            xpos.append(max_pos + np.nanmax(cur_pos) / 2)
+            # this padding value is kind of useful
+            max_pos += np.nanmax(cur_pos) + padding
             # increment the counter and mod to keep even / odd order
             i = (i + 1) % 2
+    # Set the xtick labels ...
     ax.set_xticks([])
-    return (ax, xpos)
+    return ax, xpos


### PR DESCRIPTION
…nvex hull polygons for null pvalues

this PR implements a feature thats heavily inspired by [Lino Ferriera's repo](https://github.com/linoferreira/manhattan-vector) to avoid the problem of many null p-values being represented as independent dots that make manipulation/labeling in Affinity a nightmare. 

This also allows the plot creator to control the quantile at which points are brought into the convex hull and the degree of thinning. As an example, for the pan-UKBB LDL GWAS results for ~28 million variants, we were able to plot a manhattan plot PDF using ~1 Megabyte. For ~5 million null simulated p-values, this plot goes from 21 Mb to 230 kb, which is ~100x lower without a real loss in information. We might want to implement a kind of locus-zoom plot for pinpointed loci, but overall I think that this feature greatly improves being able to use these plots as lighter-weight vector graphics.  