### PR TITLE
Implementation of karyograms for plotting tracts/ regions along the g…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: uv pip install --system ".[tests]" matplotlib
+
+      - name: Run tests
+        run: pytest tests/ -v --cov=arjun_plot --cov-report=term-missing

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -1,29 +1,52 @@
 name: documentation
 
-on: [push, pull_request, workflow_dispatch]
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
 
 jobs:
-  docs:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v5
         with:
           python-version: '3.11'
+
       - name: Install dependencies
-        run: |
-          pip install sphinx sphinx_rtd_theme myst_parser
+        run: uv pip install --system sphinx sphinx_rtd_theme myst_parser "."
+
       - name: Sphinx build
-        run: |
-          sphinx-build docs _build
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
+        run: sphinx-build docs _build
+
+      - name: Upload Pages artifact
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-pages-artifact@v3
         with:
-          publish_branch: gh-pages
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: _build/
-          force_orphan: true
+          path: _build/
+
+  deploy:
+    needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ build/
 .coverage
 docs/_build/
 _build/
+.venv/
+.claude/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,22 +3,26 @@
 exclude: 'docs/'
 fail_fast: false
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.4.0
+## general purpose linting and formatting
+  -   repo: https://github.com/pre-commit/pre-commit-hooks
+      rev: v6.0.0
+      hooks:
+      -   id: check-yaml
+      -   id: check-toml
+      -   id: end-of-file-fixer
+      -   id: trailing-whitespace
+      -   id: check-merge-conflict
+      -   id: debug-statements
+      -   id: detect-private-key
+  - repo: https://github.com/abravalheri/validate-pyproject
+    rev: v0.15
     hooks:
-    -   id: trailing-whitespace
-    -   id: end-of-file-fixer
-    -   id: check-yaml
-    -   id: check-added-large-files
--   repo: https://github.com/psf/black
-    rev: 23.1.0
-    hooks:
-    -   id: black
--   repo: https://github.com/pycqa/pydocstyle
-    rev: 4.0.0  # pick a git hash / tag to point to
-    hooks:
-    -   id: pydocstyle
--   repo: https://github.com/pycqa/flake8
-    rev: 3.7.9
-    hooks:
-    - id: flake8
+    - id: validate-pyproject
+  -   repo: https://github.com/astral-sh/ruff-pre-commit
+      rev: v0.15.6
+      hooks:
+      -   id: ruff-check
+          types_or: [ python, pyi ]
+          args: [--fix]
+      -   id: ruff-format
+          types_or: [ python, pyi ]

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![CI](https://github.com/aabiddanda/arjun_plot/actions/workflows/ci.yml/badge.svg)](https://github.com/aabiddanda/arjun_plot/actions/workflows/ci.yml) [![Documentation](https://github.com/aabiddanda/arjun_plot/actions/workflows/documentation.yaml/badge.svg)](https://github.com/aabiddanda/arjun_plot/actions/workflows/documentation.yaml) [![Python 3.11+](https://img.shields.io/badge/python-3.11%2B-blue.svg)](https://www.python.org/downloads/) [![Code style: Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
+
 # arjun_plot: customized plotting routines in matplotlib
 
 ## Rationale
@@ -6,11 +8,27 @@ Over the course of doing research, I've had to generate **many** plots. Typicall
 
 ## Modules
 
-- `utils`: contains mostly small utility functions for `matplotlib` axes
-- `admixture`: contains routines for plotting ADMIXTURE bar-plots in (built off of the `dystruct` package)
-- `pca`: some custom routines for plotting PCA in genetics applications
-- `statgen`: custom plotting for statistical genetics applications (e.g. GWAS)
+- `utils`: small utility functions for `matplotlib` axes — removing spines, adding jitter, swarm-plot coordinate transforms, and labeling multi-panel figures.
+- `admixture`: routines for plotting ADMIXTURE/STRUCTURE ancestry bar plots. Handles sorting individuals within populations and matching population columns across multiple K values. Built on top of the [dystruct](https://github.com/tyjo/dystruct) package.
+- `pca`: a `PCA` class for reading SmartPCA or PLINK eigenvector/eigenvalue output, adding population labels, and generating scatter plots with optional medoid overlays, percent-variance axis labels, and axis rotation.
+- `statgen`: statistical genetics visualizations including QQ-plots, Manhattan plots, locus-zoom plots (with optional LD coloring), gene-region tracks (via UCSC API), and single-variant genotype/phenotype plots.
+- `karyograms`: whole-genome ideogram (karyogram) figures using chromosome length data; supports overlaying painted tract intervals.
+- `spatial`: placeholder for spatial and geo-indexed plotting utilities.
+
+## Installation
+
+```bash
+git clone https://github.com/aabiddanda/arjun_plot.git
+cd arjun_plot/
+pip install .
+```
+
+Or directly from GitHub:
+
+```bash
+pip install git+https://github.com/aabiddanda/arjun_plot.git@main
+```
 
 ## Stylesheets
 
-In addition to these plotting routines, I have generated two `matplotlib` stylesheets that I have found useful when re-generating plots for presentations (particularly in LaTeX). They try to match all of the fonts that I typically use for presentations - like Fira Sans
+In addition to these plotting routines, there are two `matplotlib` stylesheets useful when re-generating plots for presentations (particularly in LaTeX). They target fonts commonly used in presentations — such as Fira Sans — to keep plot typography consistent with slide decks.

--- a/TODO.md
+++ b/TODO.md
@@ -1,2 +1,0 @@
-- General plots for spatial data
-- Include common stylesheets for plots useful in talks with font-scaling

--- a/arjun_plot/__init__.py
+++ b/arjun_plot/__init__.py
@@ -4,4 +4,4 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-__version__ = "0.0.3a"
+__version__ = "0.0.4a"

--- a/arjun_plot/admixture.py
+++ b/arjun_plot/admixture.py
@@ -7,7 +7,7 @@
 """Functions for plotting results from ADMIXTURE/STRUCTURE."""
 
 import numpy as np
-import pandas as pd
+import polars as pl
 import scipy.cluster.hierarchy
 import scipy.cluster.vq
 import scipy.stats
@@ -46,9 +46,7 @@ def subset_Q(Q, labels, order, subset=None):
     return (Q, labels, order)
 
 
-def plot_k(
-    ax, Q, lbls, order, colors, subset=None, spacing=2, bar_width=1, **kwargs
-):  # noqa
+def plot_k(ax, Q, lbls, order, colors, subset=None, spacing=2, bar_width=1, **kwargs):  # noqa
     """Plot a single run of ADMIXTURE/STRUCTURE."""
     # Subset if we need to for different populations
     Q, labels, order = subset_Q(Q, lbls, order, subset)
@@ -101,21 +99,25 @@ def plot_k(
             Q[idx] = m
             idx += 1
 
-    # Changing things to a pandas dataframe for plotting
     ancestry_matrix = Q
-    ancestry_matrix = pd.DataFrame(ancestry_matrix)
-    ancestry_matrix.plot.bar(
-        ax=ax,
-        stacked=True,
-        legend=False,
-        width=bar_width,
-        linewidth=0,
-        rasterized=True,
-        color=colors,
-    )
+    n_pops = ancestry_matrix.shape[1]
+    x = np.arange(ancestry_matrix.shape[0])
+    bottom = np.zeros(ancestry_matrix.shape[0])
+    for k in range(n_pops):
+        ax.bar(
+            x,
+            ancestry_matrix[:, k],
+            bottom=bottom,
+            width=bar_width,
+            linewidth=0,
+            rasterized=True,
+            color=colors[k],
+        )
+        bottom += ancestry_matrix[:, k]
 
     # Setting plotting parameters
     ax.set_yticklabels([])
+    ax.set_xticks(x)
     ax.set_xticklabels(labels_ordered, **kwargs)
     ax.tick_params(axis="both", which="both", length=0)
     ax.patch.set_visible(False)
@@ -124,4 +126,4 @@ def plot_k(
     ax.spines["bottom"].set_visible(False)
     ax.spines["left"].set_visible(False)
 
-    return (ax, ancestry_matrix)
+    return (ax, pl.DataFrame(ancestry_matrix))

--- a/arjun_plot/karyograms.py
+++ b/arjun_plot/karyograms.py
@@ -1,0 +1,301 @@
+import warnings
+
+import matplotlib as mpl
+import polars as pl
+import matplotlib.pyplot as plt
+from matplotlib.collections import PatchCollection
+from matplotlib.patches import Patch
+from arjun_plot.utils import remove_border, remove_ticks
+
+_DEFAULT_CHROMS = [f"chr{i}" for i in range(1, 23)]
+
+# GRCh38/hg38 primary-assembly chromosome lengths (base-pairs).
+_hg38_chrom_sizes = pl.DataFrame(
+    {
+        "chrom": [f"chr{i}" for i in range(1, 23)] + ["chrX", "chrY"],
+        "size": [
+            248_956_422, 242_193_529, 198_295_559, 190_214_555, 181_538_259,
+            170_805_979, 159_345_973, 145_138_636, 138_394_717, 133_797_422,
+            135_086_622, 133_275_309, 114_364_328, 107_043_718, 101_991_189,
+             90_338_345,  83_257_441,  80_373_285,  58_617_616,  64_444_167,
+             46_709_983,  50_818_468, 156_040_895,  57_227_415,
+        ],
+    }
+)
+
+
+def _resolve_color_map(categories, color_map, cmap):
+    """Return a category → colour dict, sampling from *cmap* when *color_map* is None."""
+    if color_map is None:
+        cm = mpl.colormaps[cmap]
+        n = len(categories)
+        return {cat: cm(i / max(n, 1)) for i, cat in enumerate(categories)}
+    missing = [c for c in categories if c not in color_map]
+    assert not missing, f"color_map is missing entries for: {missing}"
+    return color_map
+
+
+def create_ideogram(chrom_df=None, chroms=None, scaling_factor=1e6, **kwargs):
+    """Create a whole-genome ideogram with one subplot row per chromosome.
+
+    Draws a scaled rectangle for each chromosome using the lengths provided in
+    ``chrom_df``.  All spines and ticks are removed so that ancestry tracts or
+    other features can be overlaid cleanly.
+
+    :param polars.DataFrame | None chrom_df: DataFrame with columns ``chrom``
+        (e.g. ``"chr1"``) and ``size`` (length in base-pairs).  Defaults to
+        GRCh38/hg38 primary-assembly lengths when ``None``.
+    :param list | None chroms: Ordered list of chromosome names to plot (default:
+        the 22 autosomes ``["chr1", ..., "chr22"]``).  Pass e.g.
+        ``["chr1", ..., "chr22", "chrX"]`` to include the X chromosome.
+    :param float scaling_factor: Divisor applied to base-pair lengths before
+        plotting (default 1e6 → lengths in Mb).
+    :returns: ``(fig, axs, m_size)`` — the figure, list of axes (one per
+        chromosome in the order given by *chroms*), and the maximum chromosome
+        length in base-pairs.
+    :rtype: tuple
+    """
+    assert scaling_factor > 0
+    if chrom_df is None:
+        chrom_df = _hg38_chrom_sizes
+    assert "chrom" in chrom_df.columns
+    assert "size" in chrom_df.columns
+
+    if chroms is None:
+        chroms = _DEFAULT_CHROMS
+
+    absent = [c for c in chroms if c not in chrom_df["chrom"].to_list()]
+    if absent:
+        raise ValueError(f"chroms not found in chrom_df: {absent}")
+
+    fig, axs = plt.subplots(len(chroms), 1, **kwargs)
+    if len(chroms) == 1:
+        axs = [axs]
+
+    m_size = 0
+    for i, chrom in enumerate(chroms):
+        chrom_len = chrom_df.filter(pl.col("chrom") == chrom)["size"].to_numpy()[0]
+        if chrom_len > m_size:
+            m_size = chrom_len
+        remove_border(axs[i])
+        remove_ticks(axs[i])
+        axs[i].add_patch(
+            plt.Rectangle(
+                (0, 0),
+                chrom_len / scaling_factor,
+                1,
+                ls="-",
+                lw=1,
+                ec="black",
+                fc="none",
+            )
+        )
+        axs[i].plot([0, chrom_len / scaling_factor], [1, 1], color="none")
+    return fig, axs, m_size
+
+
+def draw_regions(axs, df=None, chroms=None, scaling_factor=1e6, categories=["conservative"], **kwargs):
+    """Shade genomic regions (e.g. Neanderthal deserts) on existing ideogram axes.
+
+    Filters ``df`` to rows whose ``type`` column matches any entry in ``categories``
+    and shades the corresponding intervals with :func:`matplotlib.axes.Axes.axvspan`.
+    Chromosomes not present in *chroms* are skipped with a warning.
+
+    :param list axs: List of matplotlib axes returned by :func:`create_ideogram`.
+    :param polars.DataFrame df: DataFrame with columns ``chrom``, ``start``, ``end``
+        (base-pair coordinates), and ``type`` (region category label).
+    :param list | None chroms: Ordered list of chromosome names corresponding to
+        *axs* (default: the 22 autosomes).  Must match the *chroms* used when the
+        ideogram was created.
+    :param float scaling_factor: Same divisor used when creating the ideogram
+        (default 1e6 → Mb).  Must match the value passed to :func:`create_ideogram`
+        so shaded regions land at the correct positions.
+    :param list categories: Category labels in ``df["type"]`` to include (default
+        ``["conservative"]``).
+    :param kwargs: Extra keyword arguments forwarded to
+        :func:`matplotlib.axes.Axes.axvspan` (e.g. ``alpha``, ``color``).
+    :returns: The updated ``axs`` list.
+    :rtype: list
+    """
+    if chroms is None:
+        chroms = _DEFAULT_CHROMS
+    assert len(axs) == len(chroms), (
+        f"axs has {len(axs)} entries but chroms has {len(chroms)}"
+    )
+    chrom_to_idx = {chrom: i for i, chrom in enumerate(chroms)}
+
+    assert df is not None
+    filt_deserts = df.filter(pl.col("type").is_in(categories))
+    for chrom, start, end in zip(
+        filt_deserts["chrom"].to_numpy(),
+        filt_deserts["start"].to_numpy(),
+        filt_deserts["end"].to_numpy(),
+    ):
+        if chrom not in chrom_to_idx:
+            warnings.warn(f"{chrom} is not in the provided chroms list, skipping!")
+            continue
+        axs[chrom_to_idx[chrom]].axvspan(start / scaling_factor, end / scaling_factor, **kwargs)
+    return axs
+
+
+def plot_tracts(
+    features_df, axs, chroms=None, scaling_factor=1e6, feat_idx=1, n_features=3, **kwargs
+):
+    """Overlay ancestry tracts or other genomic interval features onto ideogram axes.
+
+    Each interval in ``features_df`` is drawn as a filled rectangle occupying a
+    horizontal band within its chromosome's axis.  Multiple feature tracks can be
+    stacked by varying ``feat_idx`` across calls (1-indexed, must be ≤ ``n_features``).
+    The function also labels each chromosome axis on the left and returns a
+    :class:`matplotlib.patches.Patch` legend handle built from the supplied kwargs.
+
+    :param polars.DataFrame features_df: DataFrame with columns ``chrom``, ``start``,
+        and ``end`` (positions in base-pairs).
+    :param list axs: List of matplotlib axes returned by :func:`create_ideogram`.
+    :param list | None chroms: Ordered list of chromosome names corresponding to
+        *axs* (default: the 22 autosomes).  Must match the *chroms* used when the
+        ideogram was created.
+    :param float scaling_factor: Same divisor used when creating the ideogram (default
+        1e6 → Mb coordinates).
+    :param int feat_idx: 1-based index of this track within the stacked band (default
+        1).
+    :param int n_features: Total number of stacked tracks (determines band height,
+        default 3).
+    :param kwargs: Keyword arguments forwarded to :class:`matplotlib.patches.Rectangle`
+        and used to build the legend handle.  Must include ``facecolor``, ``edgecolor``,
+        and ``label``.
+    :returns: ``(axs, leg_elem)`` — the updated axes list and a legend patch handle.
+    :rtype: tuple
+    """
+    for c in ["chrom", "start", "end"]:
+        assert c in features_df.columns
+    assert n_features > 0
+    assert feat_idx <= n_features
+    assert feat_idx > 0
+    assert scaling_factor > 0
+
+    if chroms is None:
+        chroms = _DEFAULT_CHROMS
+    assert len(axs) == len(chroms), (
+        f"axs has {len(axs)} entries but chroms has {len(chroms)}"
+    )
+
+    for i, chrom in enumerate(chroms):
+        axs[i].set_ylabel(
+            chrom, rotation=0, va="center", ha="right", fontsize=8, labelpad=-12
+        )
+        segments = features_df.filter(pl.col("chrom") == chrom)
+        for s, e in zip(segments["start"].to_numpy(), segments["end"].to_numpy()):
+            axs[i].add_patch(
+                plt.Rectangle(
+                    (s / scaling_factor, (feat_idx - 1) / n_features),
+                    (e - s) / scaling_factor,
+                    1 / n_features,
+                    **kwargs,
+                )
+            )
+    leg_elem = Patch(
+        facecolor=kwargs["facecolor"],
+        edgecolor=kwargs["edgecolor"],
+        label=kwargs["label"],
+    )
+    return axs, leg_elem
+
+
+def plot_meta_karyogram(
+    features_df,
+    chrom_df=None,
+    chroms=None,
+    category_col="category",
+    color_map=None,
+    cmap="tab10",
+    scaling_factor=1e6,
+    alpha=0.6,
+    **kwargs,
+):
+    """Plot a barcode-style meta-karyogram aggregating many short genomic intervals.
+
+    Renders one thin vertical tick per interval across the requested chromosomes,
+    coloured by a category column (e.g. archaic ancestry type).  When thousands of
+    segments from many individuals are overlaid the tick density reveals the
+    genome-wide distribution at a glance — dense regions indicate enrichment, gaps
+    indicate deserts.  The visual style follows Figure 3A of Biddanda et al. (2026
+    bioRxiv), where Neanderthal, Denisovan, and Ghost archaic segments are overlaid
+    on a whole-genome ideogram.
+
+    Each unique category occupies an equal horizontal band of the chromosome axis
+    (``1 / n_categories`` of the total height), and each segment is drawn as a filled
+    rectangle spanning its actual genomic coordinates rather than a tick at the midpoint.
+    Rectangles are rendered via :class:`~matplotlib.collections.PatchCollection` so the
+    function remains fast for large datasets.
+
+    :param polars.DataFrame features_df: DataFrame with columns ``chrom``, ``start``,
+        ``end`` (base-pair coordinates), and a category column (see ``category_col``).
+    :param polars.DataFrame | None chrom_df: Chromosome size DataFrame passed to
+        :func:`create_ideogram` (requires columns ``chrom`` and ``size``).  Defaults
+        to GRCh38/hg38 primary-assembly lengths when ``None``.
+    :param list | None chroms: Ordered list of chromosome names to plot (default:
+        the 22 autosomes).  Pass e.g. ``["chr1", ..., "chr22", "chrX"]`` to include
+        the X chromosome.
+    :param str category_col: Column in ``features_df`` whose unique values define the
+        colour groups (default ``"category"``).
+    :param dict | None color_map: Mapping of category label → matplotlib colour string.
+        Every unique value in ``features_df[category_col]`` must be present.  If
+        ``None``, colours are sampled from ``cmap``.
+    :param str cmap: Name of a matplotlib colormap used to auto-assign colours when
+        ``color_map`` is ``None`` (default ``"tab10"``).  Any registered matplotlib
+        colormap is accepted.
+    :param float scaling_factor: Divisor applied to base-pair coordinates before
+        plotting (default 1e6 → Mb).
+    :param float alpha: Opacity of rectangles (default 0.6).
+    :param kwargs: Additional keyword arguments forwarded to :func:`create_ideogram`
+        (e.g. ``figsize``).
+    :returns: ``(fig, axs, legend_handles)`` — the figure, list of axes (one per
+        chromosome), and a list of :class:`~matplotlib.patches.Patch` legend handles
+        (one per category, ready to pass to ``ax.legend()``).
+    :rtype: tuple
+    """
+    for c in ["chrom", "start", "end", category_col]:
+        assert c in features_df.columns, f"Missing required column: '{c}'"
+    assert scaling_factor > 0
+
+    if chroms is None:
+        chroms = _DEFAULT_CHROMS
+
+    categories = sorted(features_df[category_col].unique().to_list())
+    color_map = _resolve_color_map(categories, color_map, cmap)
+
+    fig, axs, m_size = create_ideogram(chrom_df=chrom_df, chroms=chroms, **kwargs)
+    max_mb = m_size / scaling_factor
+
+    for i, chrom in enumerate(chroms):
+        ax = axs[i]
+        ax.set_ylabel(
+            chrom, rotation=0, va="center", ha="right", fontsize=8, labelpad=-12
+        )
+        ax.set_xlim(0, max_mb)
+
+        chrom_feats = features_df.filter(pl.col("chrom") == chrom)
+        if len(chrom_feats) == 0:
+            continue
+
+        n_cats = len(color_map)
+        for i, (category, color) in enumerate(color_map.items()):
+            cat_feats = chrom_feats.filter(pl.col(category_col) == category)
+            if len(cat_feats) == 0:
+                continue
+            y_lo = i / n_cats
+            h = 1 / n_cats
+            starts = cat_feats["start"].to_numpy() / scaling_factor
+            ends = cat_feats["end"].to_numpy() / scaling_factor
+            patches = [
+                plt.Rectangle((s, y_lo), e - s, h) for s, e in zip(starts, ends)
+            ]
+            pc = PatchCollection(patches, facecolor=color, edgecolor="none", alpha=alpha)
+            ax.add_collection(pc)
+
+    legend_handles = [
+        Patch(facecolor=color, edgecolor="none", label=cat)
+        for cat, color in color_map.items()
+    ]
+    return fig, axs, legend_handles

--- a/arjun_plot/pca.py
+++ b/arjun_plot/pca.py
@@ -4,7 +4,6 @@ import numpy as np
 from matplotlib import cm
 from adjustText import adjust_text
 from scipy.optimize import curve_fit
-import pandas as pd
 
 
 class PCA:
@@ -25,14 +24,17 @@ class PCA:
         :param string eval_file: File with eigenvalues in smartpca format.
 
         """
-        df = pd.read_csv(evec_file, sep=r"\s+")
-        evecs = df.values[:, :-1]
-        pop_labels = df.values[:, -1]
-        indiv_labels = df.index.values
+        with open(evec_file) as f:
+            header = f.readline()
+            lines = [line for line in f if line.strip()]
         if eval_file is None:
-            evals = df.columns[1:].astype(np.float32)
+            evals = np.array(header.split()[1:], dtype=np.float32)
         else:
             evals = np.loadtxt(eval_file)
+        rows = [line.split() for line in lines]
+        indiv_labels = np.array([r[0] for r in rows])
+        pop_labels = np.array([r[-1] for r in rows])
+        evecs = np.array([[float(x) for x in r[1:-1]] for r in rows])
         self.evals = evals
         self.evecs = evecs
         self.indiv_labels = indiv_labels
@@ -45,9 +47,10 @@ class PCA:
         :param string eval_file: File with eigenvalues in plink format.
         """
         evals = np.loadtxt(eval_file)
-        pcs = pd.read_csv(evec_file, sep=r"\s+", header=None, engine="python")
-        evecs = pcs.values[:, 2:].astype(np.float32)
-        indiv_labels = pcs.values[:, 0].astype(str)
+        with open(evec_file) as f:
+            rows = [line.split() for line in f if line.strip()]
+        indiv_labels = np.array([r[0] for r in rows])
+        evecs = np.array([[float(x) for x in r[2:]] for r in rows], dtype=np.float32)
         # Setting the underlying values after reading this
         self.evecs = evecs
         self.evals = evals

--- a/arjun_plot/statgen.py
+++ b/arjun_plot/statgen.py
@@ -371,7 +371,7 @@ def plot_gene_region_worker(
         f"https://api.genome.ucsc.edu/getData/track?genome={build};track={track};chrom={chrom};start={position_min};end={position_max}",  # noqa
         headers={"Content-Type": "application/json"},
     )
-    results = req.json()["ncbiRefSeq"]
+    results = req.json()[f"{track}"]
     genes = {}
     for g in results:
         # Want to avoid repeats & will get the longest transcript.
@@ -448,10 +448,13 @@ def plot_gene_region_worker(
     return ax
 
 
-def gene_plot(ax, chrom="chr1", position_min=1e6, position_max=2e6, **kwargs):
+def gene_plot(
+    ax, chrom="chr1", track="ncbiRefSeq", position_min=1e6, position_max=2e6, **kwargs
+):
     """Plot the genes within a region."""
     ax = plot_gene_region_worker(
         ax=ax,
+        track=track,
         chrom=chrom,
         position_min=int(np.round(position_min)),
         position_max=int(np.round(position_max)),

--- a/arjun_plot/utils.py
+++ b/arjun_plot/utils.py
@@ -1,4 +1,5 @@
 """Utility plotting functions in matplotlib."""
+
 import numpy as np
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,8 +3,11 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Welcome to arjun_plot's documentation!
-======================================
+arjun_plot — customized plotting routines for statistical genetics
+===================================================================
+
+A collection of ``matplotlib``-based utilities for ADMIXTURE/STRUCTURE bar plots,
+PCA scatter plots, genome-wide Manhattan plots, locus-zoom plots, karyograms, and more.
 
 .. toctree::
    :maxdepth: 2

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -1,16 +1,38 @@
 Installation
 ============
 
+From source
+-----------
 
-Currently, the only supported installation method is to install the package from source::
+Clone the repository and install with ``pip``::
 
   git clone https://github.com/aabiddanda/arjun_plot.git
   cd arjun_plot/
   pip install .
 
-Alternatively, you can use::
+Directly from GitHub
+--------------------
 
-  pip install git+https://github.com/user/repo.git@master
+Install the latest stable version from the ``main`` branch without cloning::
 
-We only recommend installation of the version on the main branch currently as this are the most stable versions.
+  pip install git+https://github.com/aabiddanda/arjun_plot.git@main
+
+Development install
+-------------------
+
+To install in editable mode (changes to the source are reflected immediately)::
+
+  git clone https://github.com/aabiddanda/arjun_plot.git
+  cd arjun_plot/
+  pip install -e ".[dev]"
+
+Only the ``main`` branch is recommended for general use.
+
+Optional dependencies
+---------------------
+
+Some functions require packages that are not installed by default:
+
+* ``statgen.plot_gene_region_worker`` / ``gene_plot`` — requires ``requests`` to query the UCSC Genome Browser API.
+* ``statgen.extract_ld_matrix`` — requires ``cyvcf2`` and ``tqdm`` to read VCF files.
 

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -1,12 +1,63 @@
 Introduction
 ============
 
-This is a library and collection of functions to perform common plotting routines and manipulation of matplotlib axes. Many of the functions are organized as packages to perform common plotting routines in statistical genetics in matplotlib. The primary goal is to ensure that plotting within jupyter-notebooks is easy and maximally configurable. Much of the ADMIXTURE plotting code is derived from the excellent  `dystruct <https://github.com/tyjo/dystruct>`_ package.
+``arjun_plot`` is a personal library of ``matplotlib``-based plotting routines for statistical genetics. The primary goals are to make common plot types easy to produce inside Jupyter notebooks and to keep figures maximally configurable for publication and presentation use.
 
-Many of the utilities are geared towards very easily placing: 
+Modules
+-------
 
-* removing ancillary plot borders
-* placing a y=x line on any axis for easy comparison
-* easy multi-panel labeling of plots
+**utils**
+    Small axis-level helpers that reduce boilerplate in any matplotlib workflow:
 
-This software is mainly a personal library that I use frequently and while reasonably well-tested I cannot make any guarantees on it being bug free. If you spot any strange bugs do let me know via an `issue <https://github.com/aabiddanda/arjun_plot/issues>`_.
+    * ``debox`` / ``remove_border`` — strip top/right or all axis spines.
+    * ``remove_ticks`` — hide tick marks for conceptual diagrams.
+    * ``plot_yx`` — overlay a y = x reference line using the current axis limits.
+    * ``label_multipanel`` — add panel labels (A, B, C, …) to a list of axes with configurable offsets.
+    * ``rand_jitter`` — add proportional random noise to a 1-D array to reduce overplotting.
+    * ``swarm`` — compute x-coordinates for a beeswarm / swarm plot without a heavy dependency.
+
+**admixture**
+    Bar-chart visualizations for ADMIXTURE/STRUCTURE ancestry proportion matrices (Q matrices).
+    Individuals are sorted within populations by their dominant ancestry component, and population
+    colours can be matched across multiple K values using ``match_one_Q``. Derives from the
+    `dystruct <https://github.com/tyjo/dystruct>`_ package.
+
+**pca**
+    A ``PCA`` class that ingests SmartPCA (``.evec``/``.eval``) or PLINK-formatted eigenvector
+    files and exposes methods for:
+
+    * Adding population labels from a dictionary (``add_poplabels``).
+    * Attaching arbitrary per-sample metadata (``add_meta_data``).
+    * Computing the percent variance explained by any pair of PCs (``calc_percent_var``).
+    * Generating publication-ready scatter plots with population medoid overlays,
+      non-overlapping text labels, and optional axis rotation (``plot_pca``).
+
+**statgen**
+    Statistical genetics visualizations for genome-wide and regional analyses:
+
+    * ``qqplot_pval`` — quantile–quantile plot for a set of p-values.
+    * ``manhattan_plot`` — genome-wide Manhattan plot with alternating chromosome colours
+      and convex-hull aggregation of null SNPs for compact vector output.
+    * ``locuszoom_plot`` — regional association plot with optional LD-coloured scatter
+      (R² computed against a lead variant) and grey shading for unmatched variants.
+    * ``gene_plot`` / ``plot_gene_region_worker`` — gene/exon track fetched live from the
+      UCSC Genome Browser API (hg19 or hg38).
+    * ``locus_plot`` — boxplot or violinplot of phenotype distributions stratified by
+      genotype at a single variant.
+    * ``extract_ld_matrix`` — compute an empirical R² matrix from a tabix-indexed VCF
+      over a specified genomic window.
+
+**karyograms**
+    Whole-genome ideogram (karyogram) figures. ``create_ideogram`` lays out 22 autosomal
+    chromosomes as scaled rectangles given a data frame of chromosome lengths.
+    ``plot_tracts`` overlays painted ancestry tracts or other interval-based features.
+
+**spatial**
+    Placeholder module for future spatial and geo-indexed data visualizations.
+
+Notes
+-----
+
+This software is primarily a personal library. While it is reasonably well-tested, no
+guarantee of bug-free operation is made. Bug reports and feature requests are welcome via
+`GitHub Issues <https://github.com/aabiddanda/arjun_plot/issues>`_.

--- a/docs/python-api.rst
+++ b/docs/python-api.rst
@@ -1,26 +1,74 @@
 .. _sec_python_api:
 
 API Documentation
-==================
+=================
 
-Admixture 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-.. automodule:: arjun_plot.admixture
-   :members:
+Utility Functions
+-----------------
 
+General-purpose matplotlib helpers for axis styling, annotation, and data transforms.
 
-Principal Components Analysis 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-.. automodule:: arjun_plot.pca
-   :members:
-
-
-Statistical Genetics / GWAS 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-.. automodule:: arjun_plot.statgen
-   :members:
-
-Utility Functions 
-~~~~~~~~~~~~~~~~~~~~~~~~~~
 .. automodule:: arjun_plot.utils
    :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+Admixture / STRUCTURE
+---------------------
+
+Bar-chart visualizations for ADMIXTURE/STRUCTURE ancestry proportion matrices.
+Population sorting and cross-K colour matching are handled automatically.
+
+.. automodule:: arjun_plot.admixture
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+Principal Components Analysis
+------------------------------
+
+The :class:`~arjun_plot.pca.PCA` class ingests SmartPCA or PLINK eigenvector output
+and provides scatter plots, percent-variance axis labels, and population medoid overlays.
+
+.. automodule:: arjun_plot.pca
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+Statistical Genetics / GWAS
+----------------------------
+
+Genome-wide and regional association visualizations, including Manhattan plots,
+QQ-plots, locus-zoom plots with LD coloring, gene tracks, and single-variant
+genotype/phenotype plots.
+
+.. automodule:: arjun_plot.statgen
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+Karyograms
+----------
+
+Whole-genome ideogram (karyogram) figures with support for overlaying painted
+ancestry tracts or other interval-based genomic features.
+
+.. automodule:: arjun_plot.karyograms
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+
+Spatial / Geo-indexed
+---------------------
+
+Utilities for spatial and geographically indexed data visualizations.
+
+.. automodule:: arjun_plot.spatial
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,8 @@ requires = [
     "Cartopy",
     "extension-helpers",
     "requests",
-    "cyvcf2"
+    "cyvcf2",
+    "polars"
 ]
 build-backend = "setuptools.build_meta"
 
@@ -19,8 +20,8 @@ name = "arjun_plot"
 description = "\"Personal plotting routines.\""
 keywords = ["plotting", "utilities"]
 classifiers = ["Development Status :: 3 - Alpha", "Intended Audience :: Science/Research", "Programming Language :: Python :: 3"]
-requires-python = ">= 3.9"
-dependencies = [ "numpy", "scipy", "pandas", "adjustText", "Cartopy", "cyvcf2"]
+requires-python = ">= 3.11"
+dependencies = [ "numpy", "scipy", "polars", "adjustText", "Cartopy", "cyvcf2"]
 dynamic = ["version"]
 authors = [{name = "Arjun Biddanda", email = "aabiddanda@gmail.com"}]
 
@@ -29,7 +30,7 @@ authors = [{name = "Arjun Biddanda", email = "aabiddanda@gmail.com"}]
 Homepage = "https://github.com/aabiddanda/arjun_plot"
 
 [project.optional-dependencies]
-tests = [ "pytest", "pytest-cov", "hypothesis", "flake8", "sphinx"]
+tests = [ "pytest", "pytest-cov", "pytest-xdist", "hypothesis"]
 
 [tool.setuptools]
 zip-safe = false

--- a/stylesheets/paper.mplstyle
+++ b/stylesheets/paper.mplstyle
@@ -1,3 +1,149 @@
-font.sans-serif: Arial
-figure.facecolor: w
-figure.autolayout: True
+##
+## academic.mplstyle
+## Matplotlib stylesheet for figures in academic research articles.
+##
+## Designed for population / statistical genetics publications (Nature, Nature Genetics,
+## Genetics, PNAS, eLife, etc.).  Inspired by arjun_plot and Biddanda et al. figures.
+##
+## Font: Arial (sans-serif, widely accepted by journals, editable in Illustrator/Inkscape)
+## Colorblind-aware palette as default cycle.
+## Output-ready at 300 dpi; vectors preferred.
+##
+## Usage:
+##   import matplotlib.pyplot as plt
+##   plt.style.use("academic.mplstyle")
+##
+## ─── FIGURE ────────────────────────────────────────────────────────────────
+figure.figsize        : 3.5, 3.0       ## single-column width (inches); adjust per journal
+figure.dpi            : 150            ## screen preview; use savefig.dpi for output
+figure.facecolor      : white
+figure.edgecolor      : white
+figure.frameon        : True
+
+## ─── SAVE ──────────────────────────────────────────────────────────────────
+savefig.dpi           : 300
+savefig.format        : pdf            ## vector by default; switch to 'svg' for Illustrator
+savefig.bbox          : tight
+savefig.pad_inches    : 0.05
+savefig.transparent   : False
+savefig.facecolor     : white
+savefig.edgecolor     : white
+
+## ─── FONT ──────────────────────────────────────────────────────────────────
+font.family           : sans-serif
+font.sans-serif       : Arial, Helvetica, DejaVu Sans
+font.size             : 7             ## base; journals typically want 6-8 pt
+text.usetex           : True         ## keep False so Arial renders without LaTeX
+
+## ─── AXES ──────────────────────────────────────────────────────────────────
+axes.facecolor        : white
+axes.edgecolor        : black
+axes.linewidth        : 0.8
+axes.labelsize        : 7
+axes.titlesize        : 7
+axes.titlepad         : 4
+axes.labelpad         : 3
+axes.spines.top       : False         ## cleaner look: no top/right border
+axes.spines.right     : False
+axes.spines.left      : True
+axes.spines.bottom    : True
+axes.axisbelow        : True          ## grid lines behind data
+axes.grid             : False         ## off by default; enable per-plot as needed
+axes.formatter.use_mathtext : True
+
+## Okabe-Ito colorblind-safe palette (Okabe & Ito 2008; Wong, Nature Methods 2011)
+## Explicitly recommended by Nature journals for all scientific figures.
+## Distinguishable under protanopia, deuteranopia, and tritanopia.
+## Order: warm/cool alternating so any 2–4 color subset is maximally distinct.
+##   E69F00  orange          0072B2  blue
+##   009E73  bluish green    D55E00  vermillion
+##   56B4E9  sky blue        CC79A7  reddish purple
+##   F0E442  yellow          404040  dark gray (replaces black for white-bg legibility)
+axes.prop_cycle : cycler('color', ['E69F00', '0072B2', '009E73', 'D55E00', '56B4E9', 'CC79A7', 'F0E442', '404040'])
+
+## ─── TICKS ─────────────────────────────────────────────────────────────────
+xtick.labelsize       : 6
+xtick.direction       : out
+xtick.major.size      : 3.0
+xtick.major.width     : 0.8
+xtick.minor.size      : 1.5
+xtick.minor.width     : 0.6
+xtick.minor.visible   : False
+xtick.top             : False
+xtick.bottom          : True
+xtick.major.pad       : 2
+xtick.color           : black
+
+ytick.labelsize       : 6
+ytick.direction       : out
+ytick.major.size      : 3.0
+ytick.major.width     : 0.8
+ytick.minor.size      : 1.5
+ytick.minor.width     : 0.6
+ytick.minor.visible   : False
+ytick.left            : True
+ytick.right           : False
+ytick.major.pad       : 2
+ytick.color           : black
+
+## ─── LINES ─────────────────────────────────────────────────────────────────
+lines.linewidth       : 1.0
+lines.markersize      : 4
+lines.markeredgewidth : 0.5
+
+## ─── PATCHES (bars, boxes, etc.) ───────────────────────────────────────────
+patch.linewidth       : 0.5
+patch.facecolor       : E69F00        ## Okabe-Ito orange
+patch.edgecolor       : black
+patch.force_edgecolor : True
+
+## ─── SCATTER ───────────────────────────────────────────────────────────────
+scatter.marker        : o
+scatter.edgecolors    : face
+
+## ─── GRID ──────────────────────────────────────────────────────────────────
+grid.color            : 0.85
+grid.linestyle        : --
+grid.linewidth        : 0.5
+grid.alpha            : 0.7
+
+## ─── LEGEND ────────────────────────────────────────────────────────────────
+legend.frameon        : False
+legend.fontsize       : 6
+legend.title_fontsize : 6
+legend.handlelength   : 1.5
+legend.handleheight   : 0.7
+legend.handletextpad  : 0.4
+legend.borderpad      : 0.3
+legend.labelspacing   : 0.3
+legend.columnspacing  : 1.0
+
+## ─── ERRORBAR ──────────────────────────────────────────────────────────────
+errorbar.capsize      : 2
+
+## ─── BOXPLOT ───────────────────────────────────────────────────────────────
+boxplot.flierprops.markersize  : 3
+boxplot.flierprops.linewidth   : 0.5
+boxplot.boxprops.linewidth     : 0.8
+boxplot.whiskerprops.linewidth : 0.8
+boxplot.capprops.linewidth     : 0.8
+boxplot.medianprops.linewidth  : 1.2
+boxplot.medianprops.color      : 0072B2
+
+## ─── HISTOGRAM ─────────────────────────────────────────────────────────────
+hist.bins             : auto
+
+## ─── IMAGE ─────────────────────────────────────────────────────────────────
+image.cmap            : viridis
+image.interpolation   : nearest
+image.aspect          : equal
+
+## ─── MATH TEXT ─────────────────────────────────────────────────────────────
+mathtext.fontset      : custom
+mathtext.rm           : Arial
+mathtext.it           : Arial:italic
+mathtext.bf           : Arial:bold
+
+## ─── PDF / SVG OUTPUT ──────────────────────────────────────────────────────
+pdf.fonttype          : 42            ## embed TrueType; keeps fonts editable in Illustrator
+svg.fonttype          : none          ## embed as text in SVG

--- a/stylesheets/presentation.mplstyle
+++ b/stylesheets/presentation.mplstyle
@@ -1,562 +1,156 @@
-axes.titlesize : 24
-axes.labelsize : 20
-lines.linewidth : 3
-lines.markersize : 10
-xtick.labelsize : 16
-ytick.labelsize : 16
-lines.linewidth : 2
-lines.linestyle: -
-font.sans-serif: FiraSans
-figure.facecolor: w
-figure.autolayout: True
-lines.antialiased: True
-
-
-## ***************************************************************************
-## * FONT                                                                    *
-## ***************************************************************************
-## The font properties used by `text.Text`.
-## See https://matplotlib.org/api/font_manager_api.html for more information
-## on font properties.  The 6 font properties used for font matching are
-## given below with their default values.
 ##
-## The font.family property has five values:
-##     - 'serif' (e.g., Times),
-##     - 'sans-serif' (e.g., Helvetica),
-##     - 'cursive' (e.g., Zapf-Chancery),
-##     - 'fantasy' (e.g., Western), and
-##     - 'monospace' (e.g., Courier).
-## Each of these font families has a default list of font names in decreasing
-## order of priority associated with them.  When text.usetex is False,
-## font.family may also be one or more concrete font names.
+## presentation.mplstyle
+## Matplotlib stylesheet for figures embedded in slide presentations.
 ##
-## The font.style property has three values: normal (or roman), italic
-## or oblique.  The oblique style will be used for italic, if it is not
-## present.
+## Target format : 16:9 widescreen slides
+## Font          : Atkinson Hyperlegible (designed for accessibility / legibility)
+##                 Falls back to Gill Sans, then generic sans-serif.
+## Key choices   : larger fonts, thicker lines, no top/right spines,
+##                 high-contrast colours, transparent background so figures
+##                 drop cleanly onto any slide background.
 ##
-## The font.variant property has two values: normal or small-caps.  For
-## TrueType fonts, which are scalable fonts, small-caps is equivalent
-## to using a font size of 'smaller', or about 83%% of the current font
-## size.
+## Usage:
+##   import matplotlib.pyplot as plt
+##   plt.style.use("presentation.mplstyle")
 ##
-## The font.weight property has effectively 13 values: normal, bold,
-## bolder, lighter, 100, 200, 300, ..., 900.  Normal is the same as
-## 400, and bold is 700.  bolder and lighter are relative values with
-## respect to the current weight.
+## Tip: compose with academic.mplstyle to inherit base settings and override:
+##   plt.style.use(["academic.mplstyle", "presentation.mplstyle"])
 ##
-## The font.stretch property has 11 values: ultra-condensed,
-## extra-condensed, condensed, semi-condensed, normal, semi-expanded,
-## expanded, extra-expanded, ultra-expanded, wider, and narrower.  This
-## property is not currently implemented.
-##
-## The font.size property is the default font size for text, given in pts.
-## 10 pt is the standard value.
-##
-## Note that font.size controls default text sizes.  To configure
-## special text sizes tick labels, axes, labels, title, etc, see the rc
-## settings for axes and ticks.  Special text sizes can be defined
-## relative to font.size, using the following values: xx-small, x-small,
-## small, medium, large, x-large, xx-large, larger, or smaller
+## ─── FIGURE ────────────────────────────────────────────────────────────────
+## ~half-slide width at typical 13.33 in slide width.
+## At 150 dpi this gives a crisp raster; export as PDF/SVG for vector.
+figure.figsize        : 6.0, 3.75     ## 16:9 aspect, half-slide width
+figure.dpi            : 150
+figure.facecolor      : white
+figure.edgecolor      : none
+figure.frameon        : True
 
-#font.family:  sans-serif
-#font.style:   normal
-#font.variant: normal
-#font.weight:  normal
-#font.stretch: normal
-#font.size:    10.0
+## ─── SAVE ──────────────────────────────────────────────────────────────────
+savefig.dpi           : 300
+savefig.format        : pdf
+savefig.bbox          : tight
+savefig.pad_inches    : 0.1
+savefig.transparent   : True          ## transparent bg — paste onto any slide colour
+savefig.facecolor     : none
+savefig.edgecolor     : none
 
-#font.serif:      DejaVu Serif, Bitstream Vera Serif, Computer Modern Roman, New Century Schoolbook, Century Schoolbook L, Utopia, ITC Bookman, Bookman, Nimbus Roman No9 L, Times New Roman, Times, Palatino, Charter, serif
-#font.sans-serif: DejaVu Sans, Bitstream Vera Sans, Computer Modern Sans Serif, Lucida Grande, Verdana, Geneva, Lucid, Arial, Helvetica, Avant Garde, sans-serif
-#font.cursive:    Apple Chancery, Textile, Zapf Chancery, Sand, Script MT, Felipa, cursive
-#font.fantasy:    Comic Neue, Comic Sans MS, Chicago, Charcoal, ImpactWestern, Humor Sans, xkcd, fantasy
-#font.monospace:  DejaVu Sans Mono, Bitstream Vera Sans Mono, Computer Modern Typewriter, Andale Mono, Nimbus Mono L, Courier New, Courier, Fixed, Terminal, monospace
+## ─── FONT ──────────────────────────────────────────────────────────────────
+## Install Atkinson Hyperlegible from Google Fonts or the Braille Institute
+## (https://brailleinstitute.org/freefont).  fc-cache -f after installing.
+font.family           : sans-serif
+font.sans-serif       : Atkinson Hyperlegible, Arial, DejaVu Sans
+font.size             : 14            ## legible from the back of the room
+text.usetex           : False
 
+## ─── AXES ──────────────────────────────────────────────────────────────────
+axes.facecolor        : white
+axes.edgecolor        : 103040
+axes.linewidth        : 1.2
+axes.labelsize        : 14
+axes.titlesize        : 16
+axes.titlepad         : 8
+axes.labelpad         : 5
+axes.spines.top       : False
+axes.spines.right     : False
+axes.spines.left      : True
+axes.spines.bottom    : True
+axes.axisbelow        : True
+axes.grid             : False
+axes.formatter.use_mathtext : True
 
-## ***************************************************************************
-## * TEXT                                                                    *
-## ***************************************************************************
-## The text properties used by `text.Text`.
-## See https://matplotlib.org/api/artist_api.html#module-matplotlib.text
-## for more information on text properties
-text.color: black
+## Okabe-Ito colorblind-safe palette (Okabe & Ito 2008; Wong, Nature Methods 2011)
+## Explicitly recommended by Nature journals for all scientific figures.
+## Distinguishable under protanopia, deuteranopia, and tritanopia.
+## Order: warm/cool alternating so any 2–4 color subset is maximally distinct.
+##   E69F00  orange          0072B2  blue
+##   009E73  bluish green    D55E00  vermillion
+##   56B4E9  sky blue        CC79A7  reddish purple
+##   F0E442  yellow          404040  dark gray (replaces black for white-bg legibility)
+axes.prop_cycle : cycler('color', ['E69F00', '0072B2', '009E73', 'D55E00', '56B4E9', 'CC79A7', 'F0E442', '404040'])
 
+## ─── TICKS ─────────────────────────────────────────────────────────────────
+xtick.labelsize       : 12
+xtick.direction       : out
+xtick.major.size      : 5.0
+xtick.major.width     : 1.2
+xtick.minor.size      : 2.5
+xtick.minor.width     : 0.8
+xtick.minor.visible   : False
+xtick.top             : False
+xtick.bottom          : True
+xtick.major.pad       : 4
+xtick.color           : 103040
 
-## ***************************************************************************
-## * LaTeX                                                                   *
-## ***************************************************************************
-## For more information on LaTex properties, see
-## https://matplotlib.org/tutorials/text/usetex.html
-#text.usetex: False  # use latex for all text handling. The following fonts
-                     # are supported through the usual rc parameter settings:
-                     # new century schoolbook, bookman, times, palatino,
-                     # zapf chancery, charter, serif, sans-serif, helvetica,
-                     # avant garde, courier, monospace, computer modern roman,
-                     # computer modern sans serif, computer modern typewriter
-                     # If another font is desired which can loaded using the
-                     # LaTeX \usepackage command, please inquire at the
-                     # matplotlib mailing list
-#text.latex.preamble:   # IMPROPER USE OF THIS FEATURE WILL LEAD TO LATEX FAILURES
-                        # AND IS THEREFORE UNSUPPORTED. PLEASE DO NOT ASK FOR HELP
-                        # IF THIS FEATURE DOES NOT DO WHAT YOU EXPECT IT TO.
-                        # text.latex.preamble is a single line of LaTeX code that
-                        # will be passed on to the LaTeX system. It may contain
-                        # any code that is valid for the LaTeX "preamble", i.e.
-                        # between the "\documentclass" and "\begin{document}"
-                        # statements.
-                        # Note that it has to be put on a single line, which may
-                        # become quite long.
-                        # The following packages are always loaded with usetex, so
-                        # beware of package collisions: color, geometry, graphicx,
-                        # type1cm, textcomp.
-                        # Adobe Postscript (PSSNFS) font packages may also be
-                        # loaded, depending on your font settings.
+ytick.labelsize       : 12
+ytick.direction       : out
+ytick.major.size      : 5.0
+ytick.major.width     : 1.2
+ytick.minor.size      : 2.5
+ytick.minor.width     : 0.8
+ytick.minor.visible   : False
+ytick.left            : True
+ytick.right           : False
+ytick.major.pad       : 4
+ytick.color           : 103040
 
-## FreeType hinting flag ("foo" corresponds to FT_LOAD_FOO); may be one of the
-## following (Proprietary Matplotlib-specific synonyms are given in parentheses,
-## but their use is discouraged):
-## - default: Use the font's native hinter if possible, else FreeType's auto-hinter.
-##            ("either" is a synonym).
-## - no_autohint: Use the font's native hinter if possible, else don't hint.
-##                ("native" is a synonym.)
-## - force_autohint: Use FreeType's auto-hinter.  ("auto" is a synonym.)
-## - no_hinting: Disable hinting.  ("none" is a synonym.)
-#text.hinting: force_autohint
+## ─── LINES ─────────────────────────────────────────────────────────────────
+lines.linewidth       : 2.0           ## thicker for projection
+lines.markersize      : 7
+lines.markeredgewidth : 0.8
 
-#text.hinting_factor: 8  # Specifies the amount of softness for hinting in the
-                         # horizontal direction.  A value of 1 will hint to full
-                         # pixels.  A value of 2 will hint to half pixels etc.
-#text.kerning_factor : 0  # Specifies the scaling factor for kerning values. This
-                          # is provided solely to allow old test images to remain
-                          # unchanged. Set to 6 to obtain previous behavior. Values
-                          # other than 0 or 6 have no defined meaning.
-#text.antialiased: True  # If True (default), the text will be antialiased.
-                         # This only affects the Agg backend.
+## ─── PATCHES ───────────────────────────────────────────────────────────────
+patch.linewidth       : 0.8
+patch.facecolor       : E69F00        ## Okabe-Ito orange
+patch.edgecolor       : 103040
+patch.force_edgecolor : True
 
-## The following settings allow you to select the fonts in math mode.
-#mathtext.fontset: dejavusans  # Should be 'dejavusans' (default),
-                               # 'dejavuserif', 'cm' (Computer Modern), 'stix',
-                               # 'stixsans' or 'custom' (unsupported, may go
-                               # away in the future)
-## "mathtext.fontset: custom" is defined by the mathtext.bf, .cal, .it, ...
-## settings which map a TeX font name to a fontconfig font pattern.  (These
-## settings are not used for other font sets.)
-#mathtext.bf:  sans:bold
-#mathtext.cal: cursive
-#mathtext.it:  sans:italic
-#mathtext.rm:  sans
-#mathtext.sf:  sans
-#mathtext.tt:  monospace
-#mathtext.fallback: cm  # Select fallback font from ['cm' (Computer Modern), 'stix'
-                        # 'stixsans'] when a symbol can not be found in one of the
-                        # custom math fonts. Select 'None' to not perform fallback
-                        # and replace the missing character by a dummy symbol.
-#mathtext.default: it  # The default font to use for math.
-                       # Can be any of the LaTeX font names, including
-                       # the special name "regular" for the same font
-                       # used in regular text.
+## ─── SCATTER ───────────────────────────────────────────────────────────────
+scatter.marker        : o
+scatter.edgecolors    : face
 
+## ─── GRID ──────────────────────────────────────────────────────────────────
+grid.color            : 0.82
+grid.linestyle        : --
+grid.linewidth        : 0.7
+grid.alpha            : 0.6
 
-## ***************************************************************************
-## * AXES                                                                    *
-## ***************************************************************************
-## Following are default face and edge colors, default tick sizes,
-## default fontsizes for ticklabels, and so on.  See
-## https://matplotlib.org/api/axes_api.html#module-matplotlib.axes
-#axes.facecolor:     white   # axes background color
-#axes.edgecolor:     black   # axes edge color
-#axes.linewidth:     0.8     # edge linewidth
-#axes.grid:          False   # display grid or not
-#axes.grid.axis:     both    # which axis the grid should apply to
-#axes.grid.which:    major   # gridlines at {major, minor, both} ticks
-#axes.titlelocation: center  # alignment of the title: {left, right, center}
-#axes.titlesize:     large   # fontsize of the axes title
-#axes.titleweight:   normal  # font weight of title
-#axes.titlecolor:    auto    # color of the axes title, auto falls back to
-                             # text.color as default value
-#axes.titley:        None    # position title (axes relative units).  None implies auto
-#axes.titlepad:      6.0     # pad between axes and title in points
-#axes.labelsize:     medium  # fontsize of the x any y labels
-#axes.labelpad:      4.0     # space between label and axis
-#axes.labelweight:   normal  # weight of the x and y labels
-#axes.labelcolor:    black
-#axes.axisbelow:     line    # draw axis gridlines and ticks:
-                             #     - below patches (True)
-                             #     - above patches but below lines ('line')
-                             #     - above all (False)
+## ─── LEGEND ────────────────────────────────────────────────────────────────
+legend.frameon        : False
+legend.fontsize       : 12
+legend.title_fontsize : 12
+legend.handlelength   : 1.8
+legend.handleheight   : 1.0
+legend.handletextpad  : 0.5
+legend.borderpad      : 0.4
+legend.labelspacing   : 0.4
+legend.columnspacing  : 1.2
 
-#axes.formatter.limits: -5, 6  # use scientific notation if log10
-                               # of the axis range is smaller than the
-                               # first or larger than the second
-#axes.formatter.use_locale: False  # When True, format tick labels
-                                   # according to the user's locale.
-                                   # For example, use ',' as a decimal
-                                   # separator in the fr_FR locale.
-#axes.formatter.use_mathtext: False  # When True, use mathtext for scientific
-                                     # notation.
-#axes.formatter.min_exponent: 0  # minimum exponent to format in scientific notation
-#axes.formatter.useoffset: True  # If True, the tick label formatter
-                                 # will default to labeling ticks relative
-                                 # to an offset when the data range is
-                                 # small compared to the minimum absolute
-                                 # value of the data.
-#axes.formatter.offset_threshold: 4  # When useoffset is True, the offset
-                                     # will be used when it can remove
-                                     # at least this number of significant
-                                     # digits from tick labels.
+## ─── ERRORBAR ──────────────────────────────────────────────────────────────
+errorbar.capsize      : 3
 
-#axes.spines.left:   True  # display axis spines
-#axes.spines.bottom: True
-#axes.spines.top:    True
-#axes.spines.right:  True
+## ─── BOXPLOT ───────────────────────────────────────────────────────────────
+boxplot.flierprops.markersize  : 5
+boxplot.flierprops.linewidth   : 0.8
+boxplot.boxprops.linewidth     : 1.2
+boxplot.whiskerprops.linewidth : 1.2
+boxplot.capprops.linewidth     : 1.2
+boxplot.medianprops.linewidth  : 2.0
+boxplot.medianprops.color      : 0072B2
 
-#axes.unicode_minus: True  # use Unicode for the minus symbol rather than hyphen.  See
-                           # https://en.wikipedia.org/wiki/Plus_and_minus_signs#Character_codes
-#axes.prop_cycle: cycler('color', ['1f77b4', 'ff7f0e', '2ca02c', 'd62728', '9467bd', '8c564b', 'e377c2', '7f7f7f', 'bcbd22', '17becf'])
-                  # color cycle for plot lines as list of string colorspecs:
-                  # single letter, long name, or web-style hex
-                  # As opposed to all other paramters in this file, the color
-                  # values must be enclosed in quotes for this parameter,
-                  # e.g. '1f77b4', instead of 1f77b4.
-                  # See also https://matplotlib.org/tutorials/intermediate/color_cycle.html
-                  # for more details on prop_cycle usage.
-#axes.autolimit_mode: data  # How to scale axes limits to the data.  By using:
-                            #     - "data" to use data limits, plus some margin
-                            #     - "round_numbers" move to the nearest "round" number
-#axes.xmargin:   .05  # x margin.  See `axes.Axes.margins`
-#axes.ymargin:   .05  # y margin.  See `axes.Axes.margins`
-#polaraxes.grid: True  # display grid on polar axes
-#axes3d.grid:    True  # display grid on 3d axes
+## ─── HISTOGRAM ─────────────────────────────────────────────────────────────
+hist.bins             : auto
 
+## ─── IMAGE ─────────────────────────────────────────────────────────────────
+image.cmap            : viridis
+image.interpolation   : nearest
+image.aspect          : equal
 
-## ***************************************************************************
-## * AXIS                                                                    *
-## ***************************************************************************
-#xaxis.labellocation: center  # alignment of the xaxis label: {left, right, center}
-#yaxis.labellocation: center  # alignment of the yaxis label: {bottom, top, center}
+## ─── MATH TEXT ─────────────────────────────────────────────────────────────
+mathtext.fontset      : custom
+mathtext.rm           : Atkinson Hyperlegible
+mathtext.it           : Atkinson Hyperlegible:italic
+mathtext.bf           : Atkinson Hyperlegible:bold
 
-
-## ***************************************************************************
-## * DATES                                                                   *
-## ***************************************************************************
-## These control the default format strings used in AutoDateFormatter.
-## Any valid format datetime format string can be used (see the python
-## `datetime` for details).  For example, by using:
-##     - '%%x' will use the locale date representation
-##     - '%%X' will use the locale time representation
-##     - '%%c' will use the full locale datetime representation
-## These values map to the scales:
-##     {'year': 365, 'month': 30, 'day': 1, 'hour': 1/24, 'minute': 1 / (24 * 60)}
-
-#date.autoformatter.year:        %Y
-#date.autoformatter.month:       %Y-%m
-#date.autoformatter.day:         %Y-%m-%d
-#date.autoformatter.hour:        %m-%d %H
-#date.autoformatter.minute:      %d %H:%M
-#date.autoformatter.second:      %H:%M:%S
-#date.autoformatter.microsecond: %M:%S.%f
-
-## The reference date for Matplotlib's internal date representation
-## See https://matplotlib.org/examples/ticks_and_spines/date_precision_and_epochs.py
-#date.epoch: 1970-01-01T00:00:00
-
-## ***************************************************************************
-## * TICKS                                                                   *
-## ***************************************************************************
-## See https://matplotlib.org/api/axis_api.html#matplotlib.axis.Tick
-#xtick.top:           False   # draw ticks on the top side
-#xtick.bottom:        True    # draw ticks on the bottom side
-#xtick.labeltop:      False   # draw label on the top
-#xtick.labelbottom:   True    # draw label on the bottom
-#xtick.major.size:    3.5     # major tick size in points
-#xtick.minor.size:    2       # minor tick size in points
-#xtick.major.width:   0.8     # major tick width in points
-#xtick.minor.width:   0.6     # minor tick width in points
-#xtick.major.pad:     3.5     # distance to major tick label in points
-#xtick.minor.pad:     3.4     # distance to the minor tick label in points
-#xtick.color:         black   # color of the tick labels
-#xtick.labelsize:     medium  # fontsize of the tick labels
-#xtick.direction:     out     # direction: {in, out, inout}
-#xtick.minor.visible: False   # visibility of minor ticks on x-axis
-#xtick.major.top:     True    # draw x axis top major ticks
-#xtick.major.bottom:  True    # draw x axis bottom major ticks
-#xtick.minor.top:     True    # draw x axis top minor ticks
-#xtick.minor.bottom:  True    # draw x axis bottom minor ticks
-#xtick.alignment:     center  # alignment of xticks
-
-#ytick.left:          True    # draw ticks on the left side
-#ytick.right:         False   # draw ticks on the right side
-#ytick.labelleft:     True    # draw tick labels on the left side
-#ytick.labelright:    False   # draw tick labels on the right side
-#ytick.major.size:    3.5     # major tick size in points
-#ytick.minor.size:    2       # minor tick size in points
-#ytick.major.width:   0.8     # major tick width in points
-#ytick.minor.width:   0.6     # minor tick width in points
-#ytick.major.pad:     3.5     # distance to major tick label in points
-#ytick.minor.pad:     3.4     # distance to the minor tick label in points
-#ytick.color:         black   # color of the tick labels
-#ytick.labelsize:     medium  # fontsize of the tick labels
-#ytick.direction:     out     # direction: {in, out, inout}
-#ytick.minor.visible: False   # visibility of minor ticks on y-axis
-#ytick.major.left:    True    # draw y axis left major ticks
-#ytick.major.right:   True    # draw y axis right major ticks
-#ytick.minor.left:    True    # draw y axis left minor ticks
-#ytick.minor.right:   True    # draw y axis right minor ticks
-#ytick.alignment:     center_baseline  # alignment of yticks
-
-
-
-
-## ***************************************************************************
-## * LEGEND                                                                  *
-## ***************************************************************************
-#legend.loc:           best
-#legend.frameon:       True     # if True, draw the legend on a background patch
-#legend.framealpha:    0.8      # legend patch transparency
-#legend.facecolor:     inherit  # inherit from axes.facecolor; or color spec
-#legend.edgecolor:     0.8      # background patch boundary color
-#legend.fancybox:      True     # if True, use a rounded box for the
-                                # legend background, else a rectangle
-#legend.shadow:        False    # if True, give background a shadow effect
-#legend.numpoints:     1        # the number of marker points in the legend line
-#legend.scatterpoints: 1        # number of scatter points
-#legend.markerscale:   1.0      # the relative size of legend markers vs. original
-#legend.fontsize:      medium
-#legend.title_fontsize: None    # None sets to the same as the default axes.
-
-## Dimensions as fraction of fontsize:
-#legend.borderpad:     0.4  # border whitespace
-#legend.labelspacing:  0.5  # the vertical space between the legend entries
-#legend.handlelength:  2.0  # the length of the legend lines
-#legend.handleheight:  0.7  # the height of the legend handle
-#legend.handletextpad: 0.8  # the space between the legend line and legend text
-#legend.borderaxespad: 0.5  # the border between the axes and legend edge
-#legend.columnspacing: 2.0  # column separation
-
-
-## ***************************************************************************
-## * FIGURE                                                                  *
-## ***************************************************************************
-## See https://matplotlib.org/api/figure_api.html#matplotlib.figure.Figure
-#figure.titlesize:   large     # size of the figure title (``Figure.suptitle()``)
-#figure.titleweight: normal    # weight of the figure title
-#figure.figsize:     6.4, 4.8  # figure size in inches
-#figure.dpi:         100       # figure dots per inch
-#figure.facecolor:   white     # figure facecolor
-#figure.edgecolor:   white     # figure edgecolor
-#figure.frameon:     True      # enable figure frame
-#figure.max_open_warning: 20   # The maximum number of figures to open through
-                               # the pyplot interface before emitting a warning.
-                               # If less than one this feature is disabled.
-#figure.raise_window : True    # Raise the GUI window to front when show() is called.
-
-## The figure subplot parameters.  All dimensions are a fraction of the figure width and height.
-#figure.subplot.left:   0.125  # the left side of the subplots of the figure
-#figure.subplot.right:  0.9    # the right side of the subplots of the figure
-#figure.subplot.bottom: 0.11   # the bottom of the subplots of the figure
-#figure.subplot.top:    0.88   # the top of the subplots of the figure
-#figure.subplot.wspace: 0.2    # the amount of width reserved for space between subplots,
-                               # expressed as a fraction of the average axis width
-#figure.subplot.hspace: 0.2    # the amount of height reserved for space between subplots,
-                               # expressed as a fraction of the average axis height
-
-## Figure layout
-#figure.autolayout: False  # When True, automatically adjust subplot
-                           # parameters to make the plot fit the figure
-                           # using `tight_layout`
-#figure.constrained_layout.use: False  # When True, automatically make plot
-                                       # elements fit on the figure. (Not
-                                       # compatible with `autolayout`, above).
-#figure.constrained_layout.h_pad:  0.04167  # Padding around axes objects. Float representing
-#figure.constrained_layout.w_pad:  0.04167  # inches. Default is 3./72. inches (3 pts)
-#figure.constrained_layout.hspace: 0.02     # Space between subplot groups. Float representing
-#figure.constrained_layout.wspace: 0.02     # a fraction of the subplot widths being separated.
-
-
-## ***************************************************************************
-## * IMAGES                                                                  *
-## ***************************************************************************
-#image.aspect: equal                # {equal, auto} or a number
-#image.interpolation:  antialiased  # see help(imshow) for options
-#image.cmap:   viridis              # A colormap name, gray etc...
-#image.lut:    256                  # the size of the colormap lookup table
-#image.origin: upper                # {lower, upper}
-#image.resample:  True
-#image.composite_image: True  # When True, all the images on a set of axes are
-                              # combined into a single composite image before
-                              # saving a figure as a vector graphics file,
-                              # such as a PDF.
-
-
-## ***************************************************************************
-## * CONTOUR PLOTS                                                           *
-## ***************************************************************************
-#contour.negative_linestyle: dashed  # string or on-off ink sequence
-#contour.corner_mask:        True    # {True, False, legacy}
-#contour.linewidth:          None    # {float, None} Size of the contour
-                                     # linewidths. If set to None,
-                                     # it falls back to `line.linewidth`.
-
-
-## ***************************************************************************
-## * ERRORBAR PLOTS                                                          *
-## ***************************************************************************
-errorbar.capsize: 2  # length of end cap on error bars in pixels
-
-
-## ***************************************************************************
-## * HISTOGRAM PLOTS                                                         *
-## ***************************************************************************
-#hist.bins: 10  # The default number of histogram bins or 'auto'.
-
-
-## ***************************************************************************
-## * SCATTER PLOTS                                                           *
-## ***************************************************************************
-#scatter.marker: o         # The default marker type for scatter plots.
-#scatter.edgecolors: face  # The default edge colors for scatter plots.
-
-
-## ***************************************************************************
-## * AGG RENDERING                                                           *
-## ***************************************************************************
-## Warning: experimental, 2008/10/10
-#agg.path.chunksize: 0  # 0 to disable; values in the range
-                        # 10000 to 100000 can improve speed slightly
-                        # and prevent an Agg rendering failure
-                        # when plotting very large data sets,
-                        # especially if they are very gappy.
-                        # It may cause minor artifacts, though.
-                        # A value of 20000 is probably a good
-                        # starting point.
-
-
-## ***************************************************************************
-## * PATHS                                                                   *
-## ***************************************************************************
-#path.simplify: True  # When True, simplify paths by removing "invisible"
-                      # points to reduce file size and increase rendering
-                      # speed
-#path.simplify_threshold: 0.111111111111  # The threshold of similarity below
-                                          # which vertices will be removed in
-                                          # the simplification process.
-#path.snap: True  # When True, rectilinear axis-aligned paths will be snapped
-                  # to the nearest pixel when certain criteria are met.
-                  # When False, paths will never be snapped.
-#path.sketch: None  # May be None, or a 3-tuple of the form:
-                    # (scale, length, randomness).
-                    #     - *scale* is the amplitude of the wiggle
-                    #         perpendicular to the line (in pixels).
-                    #     - *length* is the length of the wiggle along the
-                    #         line (in pixels).
-                    #     - *randomness* is the factor by which the length is
-                    #         randomly scaled.
-#path.effects:
-
-
-## ***************************************************************************
-## * SAVING FIGURES                                                          *
-## ***************************************************************************
-## The default savefig params can be different from the display params
-## e.g., you may want a higher resolution, or to make the figure
-## background white
-#savefig.dpi:       figure      # figure dots per inch or 'figure'
-#savefig.facecolor: auto        # figure facecolor when saving
-#savefig.edgecolor: auto        # figure edgecolor when saving
-#savefig.format:    png         # {png, ps, pdf, svg}
-#savefig.bbox:      standard    # {tight, standard}
-                                # 'tight' is incompatible with pipe-based animation
-                                # backends (e.g. 'ffmpeg') but will work with those
-                                # based on temporary files (e.g. 'ffmpeg_file')
-#savefig.pad_inches:   0.1      # Padding to be used when bbox is set to 'tight'
-#savefig.directory:    ~        # default directory in savefig dialog box,
-                                # leave empty to always use current working directory
-#savefig.transparent: False     # setting that controls whether figures are saved with a
-                                # transparent background by default
-#savefig.orientation: portrait  # Orientation of saved figure
-
-### tk backend params
-#tk.window_focus:   False  # Maintain shell focus for TkAgg
-
-### ps backend params
-#ps.papersize:      letter  # {auto, letter, legal, ledger, A0-A10, B0-B10}
-#ps.useafm:         False   # use of afm fonts, results in small files
-#ps.usedistiller:   False   # {ghostscript, xpdf, None}
-                            # Experimental: may produce smaller files.
-                            # xpdf intended for production of publication quality files,
-                            # but requires ghostscript, xpdf and ps2eps
-#ps.distiller.res:  6000    # dpi
-#ps.fonttype:       3       # Output Type 3 (Type3) or Type 42 (TrueType)
-
-### PDF backend params
-#pdf.compression:    6  # integer from 0 to 9
-                        # 0 disables compression (good for debugging)
-#pdf.fonttype:       3  # Output Type 3 (Type3) or Type 42 (TrueType)
-#pdf.use14corefonts : False
-#pdf.inheritcolor:   False
-
-### SVG backend params
-#svg.image_inline: True  # Write raster image data directly into the SVG file
-#svg.fonttype: path      # How to handle SVG fonts:
-                         #     path: Embed characters as paths -- supported
-                         #           by most SVG renderers
-                         #     None: Assume fonts are installed on the
-                         #           machine where the SVG will be viewed.
-#svg.hashsalt: None      # If not None, use this string as hash salt instead of uuid4
-
-### pgf parameter
-## See https://matplotlib.org/tutorials/text/pgf.html for more information.
-#pgf.rcfonts: True
-#pgf.preamble:  # See text.latex.preamble for documentation
-#pgf.texsystem: xelatex
-
-### docstring params
-#docstring.hardcopy: False  # set this when you want to generate hardcopy docstring
-
-
-## ***************************************************************************
-## * INTERACTIVE KEYMAPS                                                     *
-## ***************************************************************************
-## Event keys to interact with figures/plots via keyboard.
-## See https://matplotlib.org/users/navigation_toolbar.html for more details on
-## interactive navigation.  Customize these settings according to your needs.
-## Leave the field(s) empty if you don't need a key-map. (i.e., fullscreen : '')
-#keymap.fullscreen: f, ctrl+f   # toggling
-#keymap.home: h, r, home        # home or reset mnemonic
-#keymap.back: left, c, backspace, MouseButton.BACK  # forward / backward keys
-#keymap.forward: right, v, MouseButton.FORWARD      # for quick navigation
-#keymap.pan: p                  # pan mnemonic
-#keymap.zoom: o                 # zoom mnemonic
-#keymap.save: s, ctrl+s         # saving current figure
-#keymap.help: f1                # display help about active tools
-#keymap.quit: ctrl+w, cmd+w, q  # close the current figure
-#keymap.quit_all:               # close all figures
-#keymap.grid: g                 # switching on/off major grids in current axes
-#keymap.grid_minor: G           # switching on/off minor grids in current axes
-#keymap.yscale: l               # toggle scaling of y-axes ('log'/'linear')
-#keymap.xscale: k, L            # toggle scaling of x-axes ('log'/'linear')
-#keymap.copy: ctrl+c, cmd+c     # Copy figure to clipboard
-
-
-## ***************************************************************************
-## * ANIMATION                                                               *
-## ***************************************************************************
-#animation.html: none  # How to display the animation as HTML in
-                       # the IPython notebook:
-                       #     - 'html5' uses HTML5 video tag
-                       #     - 'jshtml' creates a Javascript animation
-#animation.writer:  ffmpeg        # MovieWriter 'backend' to use
-#animation.codec:   h264          # Codec to use for writing movie
-#animation.bitrate: -1            # Controls size/quality tradeoff for movie.
-                                  # -1 implies let utility auto-determine
-#animation.frame_format: png      # Controls frame format used by temp files
-#animation.ffmpeg_path:  ffmpeg   # Path to ffmpeg binary. Without full path
-                                  # $PATH is searched
-#animation.ffmpeg_args:           # Additional arguments to pass to ffmpeg
-#animation.convert_path: convert  # Path to ImageMagick's convert binary.
-                                  # On Windows use the full path since convert
-                                  # is also the name of a system tool.
-#animation.convert_args:          # Additional arguments to pass to convert
-#animation.embed_limit:  20.0     # Limit, in MB, of size of base64 encoded
-                                  # animation in HTML (i.e. IPython notebook)
-
-#mpl_toolkits.legacy_colorbar: True
+## ─── PDF / SVG OUTPUT ──────────────────────────────────────────────────────
+pdf.fonttype          : 42            ## embed TrueType fonts; editable in PowerPoint / Keynote
+svg.fonttype          : none

--- a/tests/test_karyograms.py
+++ b/tests/test_karyograms.py
@@ -1,0 +1,302 @@
+"""Tests for karyogram plotting utilities."""
+
+import pytest
+import polars as pl
+import matplotlib.pyplot as plt
+from arjun_plot.karyograms import (
+    create_ideogram,
+    draw_regions,
+    plot_meta_karyogram,
+    plot_tracts,
+)
+
+
+@pytest.fixture
+def chrom_df():
+    return pl.DataFrame(
+        {
+            "chrom": [f"chr{i}" for i in range(1, 23)],
+            "size": [200000000 + i * 1000000 for i in range(22)],
+        }
+    )
+
+
+@pytest.fixture
+def ideogram(chrom_df):
+    fig, axs, m_size = create_ideogram(chrom_df=chrom_df)
+    yield fig, axs, m_size
+    plt.close(fig)
+
+
+@pytest.fixture
+def neanderthal_deserts():
+    """Minimal Neanderthal desert regions spanning several autosomes."""
+    return pl.DataFrame(
+        {
+            "chrom": ["chr3", "chr3", "chr7", "chr12", "chrX"],
+            "start": [50_000_000, 120_000_000, 30_000_000, 80_000_000, 10_000_000],
+            "end": [70_000_000, 140_000_000, 55_000_000, 95_000_000, 25_000_000],
+            "type": [
+                "conservative",
+                "conservative",
+                "vernot",
+                "conservative",
+                "conservative",
+            ],
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# create_ideogram
+# ---------------------------------------------------------------------------
+
+
+def test_create_ideogram(chrom_df):
+    """Basic ideogram creation returns expected structure."""
+    fig, axs, m_size = create_ideogram(chrom_df=chrom_df)
+    assert m_size > 0
+    assert len(axs) == 22
+    plt.close(fig)
+
+
+def test_create_ideogram_no_chrom_df():
+    """Omitting chrom_df falls back to hg38 sizes and returns 22 axes."""
+    fig, axs, m_size = create_ideogram()
+    assert len(axs) == 22
+    assert m_size == 248_956_422  # chr1 is largest in hg38
+    plt.close(fig)
+
+
+def test_create_ideogram_missing_columns():
+    """A DataFrame missing required columns raises AssertionError."""
+    bad_df = pl.DataFrame({"chrom": ["chr1"], "length": [1000000]})
+    with pytest.raises(AssertionError):
+        create_ideogram(chrom_df=bad_df)
+
+
+# ---------------------------------------------------------------------------
+# draw_regions  (Neanderthal deserts test cases)
+# ---------------------------------------------------------------------------
+
+
+def test_draw_regions_conservative(ideogram, neanderthal_deserts):
+    """Conservative deserts are shaded on the correct chromosome axes."""
+    _, axs, _ = ideogram
+    # axvspan adds Polygon patches; record baseline counts first
+    baseline = [len(ax.patches) for ax in axs]
+    result = draw_regions(
+        axs,
+        df=neanderthal_deserts,
+        categories=["conservative"],
+        alpha=0.3,
+        color="steelblue",
+    )
+    assert result is axs
+    # chr3 (index 2) has two conservative entries — patch count should grow by 2
+    assert len(axs[2].patches) == baseline[2] + 2
+    # chr12 (index 11) has one conservative entry
+    assert len(axs[11].patches) == baseline[11] + 1
+
+
+def test_draw_regions_vernot(ideogram, neanderthal_deserts):
+    """Only vernot-category deserts are drawn when filtering by that type."""
+    _, axs, _ = ideogram
+    baseline = [len(ax.patches) for ax in axs]
+    draw_regions(
+        axs,
+        df=neanderthal_deserts,
+        categories=["vernot"],
+        alpha=0.3,
+        color="darkorange",
+    )
+    # chr7 (index 6) carries the vernot region — one new patch
+    assert len(axs[6].patches) == baseline[6] + 1
+    # chr3 should be untouched (only conservative entries there)
+    assert len(axs[2].patches) == baseline[2]
+
+
+def test_draw_regions_no_df(ideogram):
+    """Passing df=None raises AssertionError."""
+    _, axs, _ = ideogram
+    with pytest.raises(AssertionError):
+        draw_regions(axs, df=None)
+
+
+def test_draw_regions_unparseable_chrom_warns(ideogram, neanderthal_deserts):
+    """chrX entries produce a UserWarning and do not crash."""
+    _, axs, _ = ideogram
+    with pytest.warns(UserWarning):
+        draw_regions(
+            axs,
+            df=neanderthal_deserts,
+            categories=["conservative"],
+            alpha=0.3,
+            color="steelblue",
+        )
+
+
+def test_draw_regions_scaling_factor(ideogram, neanderthal_deserts):
+    """scaling_factor is forwarded correctly; mismatched value shifts spans."""
+    _, axs, _ = ideogram
+    # Draw the same region with the default scaling and with 1e3 (kb) scaling.
+    # Both calls should succeed; the kb-scaled span should be 1000x wider.
+    baseline = len(axs[2].patches)
+    draw_regions(axs, df=neanderthal_deserts, scaling_factor=1e6,
+                 categories=["conservative"], alpha=0.2, color="blue")
+    draw_regions(axs, df=neanderthal_deserts, scaling_factor=1e3,
+                 categories=["conservative"], alpha=0.2, color="red")
+    # Two extra patches on chr3 (index 2) per call × 2 calls = 4 new patches
+    assert len(axs[2].patches) == baseline + 4
+
+
+# ---------------------------------------------------------------------------
+# plot_tracts
+# ---------------------------------------------------------------------------
+
+
+def test_plot_tracts(ideogram):
+    """Genomic tracts are drawn onto the ideogram without error."""
+    _, axs, _ = ideogram
+    features_df = pl.DataFrame(
+        {
+            "chrom": ["chr1", "chr2"],
+            "start": [1_000_000, 2_000_000],
+            "end": [5_000_000, 8_000_000],
+        }
+    )
+    axs, leg = plot_tracts(
+        features_df,
+        axs,
+        facecolor="salmon",
+        edgecolor="none",
+        label="Neanderthal",
+    )
+    assert leg.get_label() == "Neanderthal"
+
+
+def test_plot_tracts_stacked(ideogram):
+    """feat_idx and n_features control the vertical position of tracks."""
+    _, axs, _ = ideogram
+    features_df = pl.DataFrame(
+        {
+            "chrom": ["chr1"],
+            "start": [10_000_000],
+            "end": [20_000_000],
+        }
+    )
+    # Two stacked tracks on the same ideogram should not raise
+    plot_tracts(
+        features_df,
+        axs,
+        feat_idx=1,
+        n_features=2,
+        facecolor="steelblue",
+        edgecolor="none",
+        label="track1",
+    )
+    plot_tracts(
+        features_df,
+        axs,
+        feat_idx=2,
+        n_features=2,
+        facecolor="salmon",
+        edgecolor="none",
+        label="track2",
+    )
+
+
+def test_plot_tracts_missing_columns(ideogram):
+    """A features DataFrame missing required columns raises AssertionError."""
+    _, axs, _ = ideogram
+    bad_df = pl.DataFrame({"chrom": ["chr1"], "begin": [0], "end": [1000]})
+    with pytest.raises(AssertionError):
+        plot_tracts(bad_df, axs, facecolor="blue", edgecolor="none", label="x")
+
+
+# ---------------------------------------------------------------------------
+# plot_meta_karyogram
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def archaic_tracts():
+    """Synthetic archaic introgression tracts across three categories."""
+    rng_chroms = ["chr1"] * 6 + ["chr7"] * 4 + ["chr22"] * 2
+    starts = [
+        10_000_000,
+        50_000_000,
+        80_000_000,
+        120_000_000,
+        160_000_000,
+        190_000_000,
+        15_000_000,
+        40_000_000,
+        70_000_000,
+        95_000_000,
+        5_000_000,
+        20_000_000,
+    ]
+    ends = [s + 200_000 for s in starts]
+    categories = (
+        ["Neanderthal", "Neanderthal", "Denisovan", "Ghost", "Neanderthal", "Ghost"]
+        + ["Denisovan", "Neanderthal", "Ghost", "Neanderthal"]
+        + ["Neanderthal", "Denisovan"]
+    )
+    return pl.DataFrame(
+        {"chrom": rng_chroms, "start": starts, "end": ends, "category": categories}
+    )
+
+
+def test_plot_meta_karyogram_auto_colors(chrom_df, archaic_tracts):
+    """Meta-karyogram renders without error and returns one legend handle per category."""
+    fig, axs, handles = plot_meta_karyogram(archaic_tracts, chrom_df)
+    assert len(axs) == 22
+    assert len(handles) == 3  # Denisovan, Ghost, Neanderthal
+    assert {h.get_label() for h in handles} == {"Neanderthal", "Denisovan", "Ghost"}
+    plt.close(fig)
+
+
+def test_plot_meta_karyogram_explicit_color_map(chrom_df, archaic_tracts):
+    """Explicit color_map is respected and returned in legend handles."""
+    cmap = {"Neanderthal": "steelblue", "Denisovan": "darkorange", "Ghost": "crimson"}
+    fig, axs, handles = plot_meta_karyogram(archaic_tracts, chrom_df, color_map=cmap)
+    import matplotlib.colors as mcolors
+    handle_colors = {h.get_label(): h.get_facecolor() for h in handles}
+    assert handle_colors["Neanderthal"] == mcolors.to_rgba("steelblue")
+    assert handle_colors["Ghost"] == mcolors.to_rgba("crimson")
+    plt.close(fig)
+
+
+def test_plot_meta_karyogram_ticks_added(chrom_df, archaic_tracts):
+    """LineCollections are added to chromosome axes that have features."""
+    fig, axs, _ = plot_meta_karyogram(archaic_tracts, chrom_df)
+    # chr1 (index 0) has 6 segments — at least one LineCollection per category
+    assert len(axs[0].collections) > 0
+    # chr22 (index 21) has 2 segments
+    assert len(axs[21].collections) > 0
+    # chr5 (index 4) has no segments — no collections added beyond ideogram baseline
+    assert len(axs[4].collections) == 0
+    plt.close(fig)
+
+
+def test_plot_meta_karyogram_missing_column(chrom_df, archaic_tracts):
+    """Missing required column raises AssertionError."""
+    bad_df = archaic_tracts.drop("category")
+    with pytest.raises(AssertionError, match="category"):
+        plot_meta_karyogram(bad_df, chrom_df)
+
+
+def test_plot_meta_karyogram_incomplete_color_map(chrom_df, archaic_tracts):
+    """Partial color_map (missing a category) raises AssertionError."""
+    incomplete = {"Neanderthal": "steelblue"}  # Ghost and Denisovan missing
+    with pytest.raises(AssertionError, match="color_map"):
+        plot_meta_karyogram(archaic_tracts, chrom_df, color_map=incomplete)
+
+
+def test_plot_meta_karyogram_no_chrom_df(archaic_tracts):
+    """Omitting chrom_df falls back to hg38 sizes without error."""
+    fig, axs, handles = plot_meta_karyogram(archaic_tracts)
+    assert len(axs) == 22
+    assert len(handles) == 3
+    plt.close(fig)

--- a/tests/test_pca.py
+++ b/tests/test_pca.py
@@ -1,4 +1,5 @@
 """Test PCA functions."""
+
 import pytest
 import numpy as np
 from arjun_plot.pca import PCA

--- a/tests/test_statgen.py
+++ b/tests/test_statgen.py
@@ -1,4 +1,6 @@
 """Unit testing for common statgen plots."""
+
+import pytest
 import matplotlib.pyplot as plt
 import numpy as np
 from scipy.stats import uniform
@@ -8,7 +10,9 @@ from arjun_plot.statgen import (
     locus_plot,
     locuszoom_plot,
     overlap_interval,
+    plot_null_snps,
     gene_plot,
+    plot_gene_region_worker,
     rescale_axis,
 )
 
@@ -67,9 +71,11 @@ def test_locuszoom_plot():
     chroms = np.array(chroms)
     pvals = uniform.rvs(size=chroms.size)
     pos = uniform.rvs(size=pvals.size)
+    variants = np.array([f"{c}:{p}" for (c, p) in zip(chroms, pvals)])
     locuszoom_plot(
         ax,
         chroms=chroms,
+        variants=variants,
         pos=pos,
         pvals=pvals,
         chrom="chr1",
@@ -95,3 +101,93 @@ def test_rescale_axis():
     _, ax = plt.subplots(1, 1, figsize=(6, 2))
     ax = gene_plot(ax=ax)
     rescale_axis(ax)
+
+
+def test_plot_null_snps_discontinuity():
+    """Test plot_null_snps with positions containing a gap larger than the threshold."""
+    np.random.seed(42)
+    _, ax = plt.subplots(1, 1)
+    pos = np.concatenate([np.linspace(0, 1e6, 100), np.linspace(7e6, 8e6, 100)])
+    pvals = np.random.uniform(0.5, 5.0, size=pos.size)
+    plot_null_snps(ax, pos=pos, pvals=pvals, threshold=5e6)
+
+
+def test_locuszoom_with_lead_variant():
+    """Test locuszoom plot with a lead variant and no LD matrix."""
+    _, ax = plt.subplots(1, 1)
+    np.random.seed(42)
+    n = 20
+    pos = np.linspace(0.15, 0.65, n)
+    chroms = np.array(["chr1"] * n)
+    pvals = uniform.rvs(size=n)
+    variants = np.array([f"var{i}" for i in range(n)])
+    locuszoom_plot(
+        ax,
+        chroms=chroms,
+        variants=variants,
+        pos=pos,
+        pvals=pvals,
+        chrom="chr1",
+        position_min=0.1,
+        position_max=0.7,
+        lead_variant=variants[10],
+    )
+
+
+def test_locuszoom_with_ld_matrix():
+    """Test locuszoom plot with a lead variant and an LD matrix."""
+    _, ax = plt.subplots(1, 1)
+    np.random.seed(42)
+    n = 10
+    pos = np.linspace(0.15, 0.65, n)
+    chroms = np.array(["chr1"] * n)
+    pvals = uniform.rvs(size=n)
+    variants = np.array([f"var{i:02d}" for i in range(n)])
+    ld_matrix = np.eye(n)
+    locuszoom_plot(
+        ax,
+        chroms=chroms,
+        variants=variants,
+        pos=pos,
+        pvals=pvals,
+        chrom="chr1",
+        position_min=0.1,
+        position_max=0.7,
+        lead_variant=variants[5],
+        ld_variant_ids=variants.copy(),
+        ld_matrix=ld_matrix,
+    )
+
+
+def test_plot_gene_region_invalid_build():
+    """Test that an invalid genome build raises ValueError."""
+    _, ax = plt.subplots(1, 1)
+    with pytest.raises(ValueError):
+        plot_gene_region_worker(ax, build="hg17")
+
+
+def test_plot_gene_region_invalid_track():
+    """Test that an invalid UCSC track raises ValueError."""
+    _, ax = plt.subplots(1, 1)
+    with pytest.raises(ValueError):
+        plot_gene_region_worker(ax, track="RefSeq")
+
+
+def test_locus_plot_violinplot():
+    """Test locus_plot using a violinplot instead of a boxplot."""
+    _, ax = plt.subplots(1, 1)
+    np.random.seed(42)
+    geno = np.random.binomial(2, 0.4, size=200)
+    pheno = geno * 0.1 + np.random.normal(size=200)
+    _, ns, _ = locus_plot(ax, geno, pheno, boxplot=False)
+    assert np.sum(ns) == 200
+
+
+def test_locus_plot_few_genotypes():
+    """Test locus_plot warning when fewer than 3 genotype classes are observed."""
+    _, ax = plt.subplots(1, 1)
+    np.random.seed(42)
+    geno = np.zeros(50, dtype=int)
+    pheno = np.random.normal(size=50)
+    with pytest.warns(UserWarning):
+        locus_plot(ax, geno, pheno)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,12 +1,12 @@
 """Test ancillary plotting utilities."""
+
 import pytest
+import numpy as np
 import matplotlib.pyplot as plt
 from arjun_plot import utils
 
 
-@pytest.mark.parametrize(
-    "test_in,test_seed,test_scale", [([-1, 0, 1], 42, 0.01)]
-)  # noqa
+@pytest.mark.parametrize("test_in,test_seed,test_scale", [([-1, 0, 1], 42, 0.01)])  # noqa
 def test_rand_jitter(test_in, test_seed, test_scale):
     """Testing random jitter."""
     jitter_res = utils.rand_jitter(test_in, scale=test_scale)
@@ -54,3 +54,20 @@ def test_label_multipanel():
     with pytest.raises(AssertionError):
         _, axs = plt.subplots(1, 2)
         utils.label_multipanel(axs, labels)
+
+
+def test_rand_jitter_with_seed():
+    """Testing random jitter with a fixed seed is deterministic."""
+    arr = [-1, 0, 1]
+    r1 = utils.rand_jitter(arr, scale=0.01, seed=42)
+    r2 = utils.rand_jitter(arr, scale=0.01, seed=42)
+    np.testing.assert_array_equal(r1, r2)
+
+
+def test_swarm():
+    """Testing swarm plot coordinate transform."""
+    arr = np.linspace(0, 1, 60)
+    x = utils.swarm(arr)
+    assert x.shape == arr.shape
+    x2 = utils.swarm(arr, nbins=5, width=2.0)
+    assert x2.shape == arr.shape


### PR DESCRIPTION
…enome (#4)

* test: fixed some tests for locuszoom

* draft: draft addition of karyograms

* draft: revised precommit to use ruff

* draft: ruff now works

* draft: updated small amount of testing and loading

* feat: small update on stylesheets

* refactor: replace pandas with polars/native IO in admixture and pca

Removes the pandas dependency from admixture.py and pca.py. In admixture.py, switches to direct matplotlib bar calls and returns a polars DataFrame. In pca.py, replaces pd.read_csv (which required regex whitespace splitting) with native Python file IO feeding into numpy arrays.



* doc: improving some clear documentation

* test: fix draw_regions/plot_tracts bugs and add Neanderthal desert tests

- Add missing imports (warnings, matplotlib.patches.Patch)
- draw_regions: fix stale deserts_df → df parameter reference
- plot_tracts: remove tqdm dep, fix df → features_df and nea_segments → segments
- Expand test suite with neanderthal_deserts fixture covering conservative/vernot categories, unparseable chroms (chrX warning), stacked tracks, and column validation



* ci: add test workflow and README badges

Add GitHub Actions CI workflow running pytest across Python 3.11/3.12. Add CI, documentation, Python version, and Ruff badges to README.



* feat: add plot_meta_karyogram for barcode-style archaic tract visualisation

Implements a meta-karyogram (à la Fig 3A of Zhang et al. 2026 bioRxiv) that renders thousands of short genomic intervals as thin vertical ticks coloured by category (e.g. Neanderthal/Denisovan/Ghost), using LineCollection for efficient rendering. Supports auto colour assignment and explicit color_map, returns legend handles ready for ax.legend(). Adds 5 tests covering auto/explicit colour maps, tick placement, missing columns, and incomplete color_map.



* refactor: add chroms parameter and shared color-map helper to karyograms

All four public functions (create_ideogram, draw_regions, plot_tracts, plot_meta_karyogram) now accept a chroms parameter (default: the 22 autosomes) so sex chromosomes or custom subsets can be plotted without forking logic.  draw_regions replaces the fragile int(chrom[3:])-1 index arithmetic with a chrom→index dict, making chrX/chrY work cleanly.

Extracts _resolve_color_map to centralise the color_map=None fallback and validation that was previously inlined in plot_meta_karyogram.

Also fixes a pre-existing bug in create_ideogram where remove_border, remove_ticks, and add_patch were gated on chrom_len >= m_size, meaning only the largest chromosome (chr1) ever had its axis set up.



* feat: hg38 default chrom sizes and scaling_factor in draw_regions

Adds _hg38_chrom_sizes (GRCh38 primary assembly) as a module-level fallback so chrom_df=None works in create_ideogram and plot_meta_karyogram — common-case callers no longer need to supply a size table.

Adds scaling_factor to draw_regions (default 1e6) to replace the hardcoded 1e6 divisor, so shaded regions stay aligned when the ideogram was built with a non-default scaling factor.



* fix: draw full segment rectangles in plot_meta_karyogram, stacked by category

Replaces vertical LineCollection ticks at segment midpoints with PatchCollection rectangles spanning actual start→end coordinates. Each category occupies an equal 1/n_categories band on the y-axis, matching the stacking behaviour of plot_tracts.

Removes the linewidth parameter (no longer meaningful), switches legend handles from Line2D to Patch, and updates the colour comparison in tests to use RGBA tuples since Patch.get_facecolor() returns normalised floats.



* ci: modernise workflows to use uv and native GitHub Pages deployment



---------